### PR TITLE
Added metadata field

### DIFF
--- a/lib/Netflow/lib/Netflow.js
+++ b/lib/Netflow/lib/Netflow.js
@@ -28,6 +28,7 @@ var Netflow = module.exports = function () {
                     }
                 });
             }
+            newPacket.metadata = rinfo;
             this.emit.call(eventContext, "packet", newPacket);
         } catch (err) {
             this.emit.call(eventContext, "error", err);


### PR DESCRIPTION
First off: thank you for this library.

According to the [Cisco Specifications](http://www.cisco.com/en/US/technologies/tk648/tk362/technologies_white_paper09186a00800a3db9_ps6601_Products_White_Paper.html), the different flows are identified by both the source_id and the source's IP Address, because the flow_id can be repeated across multiple devices.

So I added to the packets returned by the library a "metadata" field, which includes: 
- address: "192.168.1.1"
- family: "IPv4"
- port: 64125
- size: 190

This way we can use address to identify different flows across devices.
